### PR TITLE
Update sha256 import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.1.0 - 2026-06-dd
 
+### Added
+- Add `@noble/hashes@2.2.0` dependency.
+
 ### Changed
 - Update @noble/hashes deprecated sha256 import statement.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/bbs-signatures ChangeLog
 
+## 3.1.0 - 2026-06-dd
+
+### Changed
+- Update @noble/hashes deprecated sha256 import statement.
+
 ## 3.0.0 - 2024-08-19
 
 ### Changed

--- a/lib/bbs/ciphersuites.js
+++ b/lib/bbs/ciphersuites.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2023-2024 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023-2026 Digital Bazaar, Inc. All rights reserved.
  */
 import {
   expand_message_xmd, expand_message_xof

--- a/lib/bbs/ciphersuites.js
+++ b/lib/bbs/ciphersuites.js
@@ -6,7 +6,7 @@ import {
 } from '@noble/curves/abstract/hash-to-curve';
 import {assertType} from '../assert.js';
 import {bls12_381} from '@noble/curves/bls12-381';
-import {sha256} from '@noble/hashes/sha256';
+import {sha256} from '@noble/hashes/sha2.js';
 import {shake256} from '@noble/hashes/sha3';
 
 // Note: This file uses naming conventions that match the IETF BBS RFCs.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@noble/curves": "^1.3.0"
+    "@noble/curves": "^1.3.0",
+    "@noble/hashes": "^2.2.0"
   },
   "devDependencies": {
     "c8": "^9.0.0",


### PR DESCRIPTION
Update deprecated @noble/hashes import statement for sha256.

Reference new import statement from documentation:
https://github.com/paulmillr/noble-hashes#sha2-sha256-sha384-sha512-and-others

```javascript
import { sha256 } from '@noble/hashes/sha2.js';
```